### PR TITLE
Remove binary images, use inline SVG icons

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.onnx filter=lfs diff=lfs merge=lfs -text
+*.pt filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+name: Deploy frontend
+on:
+  push:
+    branches: [ main ]
+permissions:
+  contents: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./frontend
+          publish_branch: gh-pages

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# test_agent
+# Cat Detector
+
+A simple Progressive Web App that detects cats in images using a lightweight ONNX model running entirely in the browser.
+
+## Usage
+Open `frontend/index.html` locally or visit the GitHub Pages site. Upload an image and click **Predict** to see if a cat is detected.
+
+## Development
+No backend or Docker is required. The app loads `squeezenet1_1.onnx` with [ONNX Runtime Web](https://onnxruntime.ai/docs/api/js/).
+
+## Deployment
+GitHub Actions automatically publishes the `frontend` directory to the `gh-pages` branch.
+
+## Large files
+Sample test images and model weights are tracked with Git LFS. If you clone this
+repository without LFS files, run `git lfs pull` to fetch them. The test image
+dataset is omitted from the repository to keep the pull request lightweight.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,63 @@
+const input = document.getElementById('image-input');
+const preview = document.getElementById('preview');
+const predictBtn = document.getElementById('predict-btn');
+const result = document.getElementById('result');
+let file;
+let session;
+
+input.addEventListener('change', () => {
+  file = input.files[0];
+  if (file) {
+    const reader = new FileReader();
+    reader.onload = e => {
+      preview.src = e.target.result;
+      preview.style.display = 'block';
+      predictBtn.disabled = false;
+    };
+    reader.readAsDataURL(file);
+  }
+});
+
+async function loadModel() {
+  if (!session) {
+    result.textContent = 'Downloading model...';
+    session = await ort.InferenceSession.create('squeezenet1_1.onnx');
+  }
+}
+
+predictBtn.addEventListener('click', async () => {
+  if (!file) return;
+  await loadModel();
+  result.textContent = 'Predicting...';
+  const size = 224;
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(preview, 0, 0, size, size);
+  const { data } = ctx.getImageData(0, 0, size, size);
+  const inputData = new Float32Array(3 * size * size);
+  for (let i = 0; i < size * size; i++) {
+    inputData[i] = (data[i * 4] / 255 - 0.485) / 0.229;
+    inputData[i + size * size] = (data[i * 4 + 1] / 255 - 0.456) / 0.224;
+    inputData[i + 2 * size * size] = (data[i * 4 + 2] / 255 - 0.406) / 0.225;
+  }
+  const tensor = new ort.Tensor('float32', inputData, [1, 3, size, size]);
+  const output = await session.run({ 'input.1': tensor });
+  const scores = output[session.outputNames[0]].data;
+  const exps = scores.map(Math.exp);
+  const sumExp = exps.reduce((a, b) => a + b, 0);
+  const catIndices = [281, 282, 283, 284, 285];
+  let catProb = 0;
+  for (const idx of catIndices) catProb += exps[idx];
+  catProb /= sumExp;
+  result.textContent = catProb > 0.5
+    ? `Cat detected (conf ${catProb.toFixed(2)})`
+    : `No cat detected (conf ${catProb.toFixed(2)})`;
+});
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('service-worker.js');
+  });
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="apple-mobile-web-app-title" content="Cat Detector">
+  <link rel="apple-touch-icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMDAgMTAwJz48dGV4dCB5PScuOWVtJyBmb250LXNpemU9JzkwJz7wn5CxPC90ZXh0Pjwvc3ZnPg==">
+  <link rel="manifest" href="manifest.json">
+  <title>Cat Detector</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Cat Detector</h1>
+  <input type="file" id="image-input" accept="image/*">
+  <div id="preview-container">
+    <img id="preview" alt="Preview" style="display:none;" />
+  </div>
+  <button id="predict-btn" disabled>Predict</button>
+  <p id="result"></p>
+  <script src="https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/ort.min.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/frontend/manifest.json
+++ b/frontend/manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "Cat Detector",
+  "short_name": "CatDetector",
+  "display": "standalone",
+  "start_url": ".",
+  "icons": [
+    {
+      "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMDAgMTAwJz48dGV4dCB5PScuOWVtJyBmb250LXNpemU9JzkwJz7wn5CxPC90ZXh0Pjwvc3ZnPg==",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMDAgMTAwJz48dGV4dCB5PScuOWVtJyBmb250LXNpemU9JzkwJz7wn5CxPC90ZXh0Pjwvc3ZnPg==",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/frontend/service-worker.js
+++ b/frontend/service-worker.js
@@ -1,0 +1,18 @@
+const CACHE_NAME = 'cat-detector-cache-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/style.css',
+  '/app.js',
+  '/manifest.json'
+];
+self.addEventListener('install', e => {
+  e.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+self.addEventListener('fetch', e => {
+  e.respondWith(
+    caches.match(e.request).then(resp => resp || fetch(e.request))
+  );
+});

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,15 @@
+body {
+    font-family: Arial, sans-serif;
+    padding: 1rem;
+    text-align: center;
+}
+
+#preview {
+    max-width: 100%;
+    margin-top: 1rem;
+}
+
+button {
+    margin-top: 1rem;
+    padding: 0.5rem 1rem;
+}

--- a/test_model.py
+++ b/test_model.py
@@ -1,0 +1,57 @@
+import os
+import numpy as np
+from PIL import Image
+import onnxruntime as ort
+
+MODEL_PATH = 'frontend/squeezenet1_1.onnx'
+CLASSES_URL = 'https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt'
+
+# Load class labels
+import urllib.request
+with urllib.request.urlopen(CLASSES_URL) as f:
+    classes = [line.decode('utf-8').strip() for line in f.readlines()]
+
+cat_idx = list(range(281, 286))  # tabby to Egyptian cat inclusive
+# dog classes from 151 to 268 inclusive
+dog_idx = list(range(151, 269))
+
+session = ort.InferenceSession(MODEL_PATH, providers=['CPUExecutionProvider'])
+input_name = session.get_inputs()[0].name
+
+def preprocess(img: Image.Image) -> np.ndarray:
+    img = img.resize((224, 224))
+    arr = np.array(img).astype('float32') / 255.0
+    arr = (arr - np.array([0.485, 0.456, 0.406], dtype=np.float32)) / np.array([0.229, 0.224, 0.225], dtype=np.float32)
+    arr = arr.transpose(2, 0, 1)  # HWC -> CHW
+    return arr[np.newaxis, :]
+
+def predict(img_path):
+    img = Image.open(img_path).convert('RGB')
+    x = preprocess(img)
+    outputs = session.run(None, {input_name: x})
+    probs = np.exp(outputs[0]) / np.exp(outputs[0]).sum(axis=1, keepdims=True)
+    idx = probs.argmax(axis=1)[0]
+    return idx, probs[0, idx]
+
+def eval_dir(dir_path, target_idx_set):
+    correct = 0
+    total = 0
+    for filename in os.listdir(dir_path):
+        if filename.lower().endswith('.jpg'):
+            total += 1
+            idx, conf = predict(os.path.join(dir_path, filename))
+            if idx in target_idx_set:
+                correct += 1
+    return correct, total
+
+if __name__ == '__main__':
+    cat_correct, cat_total = eval_dir('test_images/cats', set(cat_idx))
+    dog_correct, dog_total = eval_dir('test_images/dogs', set(dog_idx))
+    total_correct = cat_correct + dog_correct
+    total = cat_total + dog_total
+    acc = total_correct / total if total else 0
+    print(f'Cat accuracy: {cat_correct}/{cat_total}')
+    print(f'Dog accuracy: {dog_correct}/{dog_total}')
+    print(f'Total accuracy: {acc*100:.1f}%')
+    if acc < 0.7:
+        print('WARNING: accuracy below 70%')


### PR DESCRIPTION
## Summary
- replace PNG icons with inline SVG to avoid binary files
- update manifest and HTML to reference the inline icon
- remove icon entries from service worker cache list

## Testing
- `python3 -m py_compile test_model.py`

------
https://chatgpt.com/codex/tasks/task_e_684efbb0acfc83209e137da88d444d4b