### PR TITLE
Fix service worker paths and update tests

### DIFF
--- a/frontend/service-worker.js
+++ b/frontend/service-worker.js
@@ -1,12 +1,13 @@
-const CACHE_NAME = 'cat-detector-cache-v2';
+const CACHE_NAME = 'cat-detector-cache-v3';
+// Cache assets relative to the service worker scope so it works when the
+// application is served from a subfolder (e.g. GitHub Pages).
 const ASSETS = [
-  '/',
-  '/index.html',
-  '/style.css',
-  '/app.js',
-  '/manifest.json',
-  '/ort.min.js',
-  '/squeezenet1_1.onnx'
+  './index.html',
+  './style.css',
+  './app.js',
+  './manifest.json',
+  './ort.min.js',
+  './squeezenet1_1.onnx'
 ];
 self.addEventListener('install', e => {
   e.waitUntil(

--- a/test_model.py
+++ b/test_model.py
@@ -37,7 +37,7 @@ def eval_dir(dir_path, target_idx_set):
     correct = 0
     total = 0
     for filename in os.listdir(dir_path):
-        if filename.lower().endswith('.jpg'):
+        if filename.lower().endswith(('.jpg', '.jpeg')):
             total += 1
             idx, conf = predict(os.path.join(dir_path, filename))
             if idx in target_idx_set:
@@ -45,8 +45,10 @@ def eval_dir(dir_path, target_idx_set):
     return correct, total
 
 if __name__ == '__main__':
-    cat_correct, cat_total = eval_dir('test_images/cats', set(cat_idx))
-    dog_correct, dog_total = eval_dir('test_images/dogs', set(dog_idx))
+    # Use the sample images packaged in the repository for testing. The
+    # directories mirror the ones from Ivanx32/test_agent on GitHub.
+    cat_correct, cat_total = eval_dir('test_data/cats', set(cat_idx))
+    dog_correct, dog_total = eval_dir('test_data/dogs', set(dog_idx))
     total_correct = cat_correct + dog_correct
     total = cat_total + dog_total
     acc = total_correct / total if total else 0


### PR DESCRIPTION
## Summary
- ensure service worker caches assets relative to its scope
- update test paths to use `test_data`
- allow `.jpeg` images in the test script

## Testing
- `python test_model.py`

------
https://chatgpt.com/codex/tasks/task_e_684f3ab1d8408320a265de877aa137a0