### PR TITLE
Fix onnxruntime-web model loading in PWA

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5,6 +5,12 @@ const result = document.getElementById('result');
 let file;
 let session;
 
+// Ensure WASM backend loads from relative paths and doesn't require
+// cross-origin isolation (GitHub Pages lacks proper headers).
+ort.env.wasm.wasmPaths = './';
+ort.env.wasm.numThreads = 1;
+ort.env.wasm.proxy = false;
+
 input.addEventListener('change', () => {
   file = input.files[0];
   if (file) {
@@ -22,7 +28,10 @@ async function loadModel() {
   if (!session) {
     result.textContent = 'Downloading model...';
     try {
-      session = await ort.InferenceSession.create('squeezenet1_1.onnx');
+      const modelUrl = new URL('./squeezenet1_1.onnx', import.meta.url).href;
+      session = await ort.InferenceSession.create(modelUrl, {
+        executionProviders: ['wasm']
+      });
       result.textContent = 'Model loaded. Click Predict.';
     } catch (e) {
       result.textContent = 'Failed to load model.';

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,6 +21,6 @@
   <button id="predict-btn" disabled>Predict</button>
   <p id="result"></p>
   <script src="ort.min.js"></script>
-  <script src="app.js"></script>
+  <script type="module" src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- configure `ort.env.wasm` so the model loads from relative paths
- disable multi-threading which fails on GitHub Pages
- load the model URL using `import.meta.url`
- mark `app.js` as module

## Testing
- `python test_model.py`

------
https://chatgpt.com/codex/tasks/task_e_684f3f9a63948320a16bd810bc8006ea