### PR TITLE
Improve prediction logging

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2,6 +2,13 @@ const input = document.getElementById('image-input');
 const preview = document.getElementById('preview');
 const predictBtn = document.getElementById('predict-btn');
 const result = document.getElementById('result');
+const logEl = document.getElementById('log');
+
+function log(message) {
+  logEl.textContent += message + '\n';
+  logEl.scrollTop = logEl.scrollHeight;
+  console.log(message);
+}
 let file;
 let session;
 
@@ -19,6 +26,7 @@ if (typeof SharedArrayBuffer === 'undefined' || !crossOriginIsolated) {
 input.addEventListener('change', () => {
   file = input.files[0];
   if (file) {
+    log(`Selected file: ${file.name}`);
     const reader = new FileReader();
     reader.onload = e => {
       preview.src = e.target.result;
@@ -31,6 +39,7 @@ input.addEventListener('change', () => {
 
 async function loadModel() {
   if (!session) {
+    log('Downloading model...');
     result.textContent = 'Downloading model...';
     try {
       const modelUrl = new URL('./squeezenet1_1.onnx', import.meta.url).href;
@@ -38,15 +47,21 @@ async function loadModel() {
         executionProviders: ['wasm']
       });
       result.textContent = 'Model loaded. Click Predict.';
+      log('Model loaded');
     } catch (e) {
       result.textContent = 'Failed to load model.';
+      log('Failed to load model: ' + e);
       throw e;
     }
+  }
+  else {
+    log('Model already loaded');
   }
 }
 
 predictBtn.addEventListener('click', async () => {
   if (!file) return;
+  log('Starting prediction');
   await loadModel();
   result.textContent = 'Predicting...';
   const size = 224;
@@ -63,6 +78,7 @@ predictBtn.addEventListener('click', async () => {
     inputData[i + 2 * size * size] = (data[i * 4 + 2] / 255 - 0.406) / 0.225;
   }
   const tensor = new ort.Tensor('float32', inputData, [1, 3, size, size]);
+  log('Running inference');
   const output = await session.run({ 'input.1': tensor });
   const scores = output[session.outputNames[0]].data;
   const exps = scores.map(Math.exp);
@@ -74,10 +90,15 @@ predictBtn.addEventListener('click', async () => {
   result.textContent = catProb > 0.5
     ? `Cat detected (conf ${catProb.toFixed(2)})`
     : `No cat detected (conf ${catProb.toFixed(2)})`;
+  log(`Prediction done. Cat probability: ${catProb.toFixed(4)}`);
 });
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('service-worker.js');
+    navigator.serviceWorker.register('service-worker.js').then(() => {
+      log('Service worker registered');
+    }).catch(e => {
+      log('Service worker registration failed: ' + e);
+    });
   });
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,13 +13,14 @@
 </head>
 <body>
   <h1>Cat Detector</h1>
-  <p id="version">Версия 0.0.6</p>
+  <p id="version">Версия 0.0.7</p>
   <input type="file" id="image-input" accept="image/*">
   <div id="preview-container">
     <img id="preview" alt="Preview" style="display:none;" />
   </div>
   <button id="predict-btn" disabled>Predict</button>
   <p id="result"></p>
+  <pre id="log"></pre>
   <script src="https://cdn.jsdelivr.net/npm/onnxruntime-web@1.20.1/dist/ort.min.js"></script>
   <script type="module" src="app.js"></script>
 </body>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -13,3 +13,15 @@ button {
     margin-top: 1rem;
     padding: 0.5rem 1rem;
 }
+
+#log {
+    margin-top: 1rem;
+    padding: 0.5rem;
+    max-height: 200px;
+    overflow-y: auto;
+    background: #f0f0f0;
+    border: 1px solid #ccc;
+    text-align: left;
+    white-space: pre-wrap;
+    user-select: text;
+}


### PR DESCRIPTION
## Summary
- add on-page logging for model loading and predictions
- style the log window with scrollable area
- bump app version to 0.0.7

## Testing
- `pytest -q`
- `python test_model.py`

------
https://chatgpt.com/codex/tasks/task_e_684ffa130910832098bbb238b9efa9e6