### PR TITLE
Fix inference input key

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -48,6 +48,8 @@ async function loadModel() {
       });
       result.textContent = 'Model loaded. Click Predict.';
       log('Model loaded');
+      log('Inputs: ' + session.inputNames.join(', '));
+      log('Outputs: ' + session.outputNames.join(', '));
     } catch (e) {
       result.textContent = 'Failed to load model.';
       log('Failed to load model: ' + e);
@@ -83,7 +85,7 @@ predictBtn.addEventListener('click', async () => {
   log('Running inference');
   let output;
   try {
-    output = await session.run({ data: tensor });
+    output = await session.run({ [session.inputNames[0]]: tensor });
   } catch (e) {
     log('Inference failed: ' + e);
     result.textContent = 'Inference error';

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,7 +13,7 @@
 </head>
 <body>
   <h1>Cat Detector</h1>
-  <p id="version">Версия 0.0.8</p>
+  <p id="version">Версия 0.0.9</p>
   <input type="file" id="image-input" accept="image/*">
   <div id="preview-container">
     <img id="preview" alt="Preview" style="display:none;" />


### PR DESCRIPTION
## Summary
- fix ONNX Runtime `session.run` call to use correct input name
- log model input and output names for easier debugging
- bump web app version in UI

## Testing
- `python3 test_model.py`

------
https://chatgpt.com/codex/tasks/task_e_685fe7eac3308320a5c648f957758b33