### PR TITLE
Implement portrait lock using CSS transform

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -131,20 +131,20 @@ if ('serviceWorker' in navigator) {
   });
 }
 
-/* === ORIENTATION LOCK ======================================= */
-const lockOverlay = document.getElementById('rotate-lock');
+/* ===== ORIENTATION-FIX  ====================================== */
+const wrapper = document.getElementById('root-rotate-wrapper');
 
-function checkOrientation(){
-  const isPortrait = window.matchMedia('(orientation: portrait)').matches;
-  lockOverlay.hidden = isPortrait;
-  document.body.style.visibility = isPortrait ? 'visible' : 'hidden';
+function applyOrientation(){
+  const angle = screen.orientation?.angle || window.orientation || 0;
+  if (Math.abs(angle) === 90){
+    const dir = angle === 90 ? -90 : 90;
+    wrapper.style.transform = `rotate(${dir}deg) translateY(${dir===90?'-100dvh':'0'})`;
+  }else{
+    wrapper.style.transform = '';
+  }
 }
-
-checkOrientation();
-window.addEventListener('orientationchange', checkOrientation);
-window.addEventListener('resize', checkOrientation);
-
-if (screen.orientation?.lock) {
-  screen.orientation.lock('portrait').catch(()=>{});
-}
-/* === END ORIENTATION LOCK =================================== */
+applyOrientation();
+window.addEventListener('orientationchange', applyOrientation);
+window.addEventListener('resize', applyOrientation);
+screen.orientation?.lock?.('portrait').catch(()=>{});
+/* ===== END ORIENTATION-FIX =================================== */

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,22 +15,21 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h1>Cat Detector</h1>
-  <p id="version">Версия 0.0.10</p>
-  <input type="file" id="image-input" accept="image/*">
-  <div id="preview-container">
-    <img id="preview" alt="Preview" style="display:none;" />
-  </div>
-  <button id="predict-btn" disabled>Predict</button>
-  <div id="spinner"></div>
-  <p id="result"></p>
-  <div id="rotate-lock" hidden>
-    <div class="msg">Поверните устройство<br>в&nbsp;портретный&nbsp;режим</div>
-  </div>
-  <section id="log-wrapper">
-    <pre id="log"></pre>
-    <button id="copy-log-btn" title="Copy entire log">Copy log</button>
-  </section>
+  <div id="root-rotate-wrapper">
+    <h1>Cat Detector</h1>
+    <p id="version">Версия 0.0.10</p>
+    <input type="file" id="image-input" accept="image/*">
+    <div id="preview-container">
+      <img id="preview" alt="Preview" style="display:none;" />
+    </div>
+    <button id="predict-btn" disabled>Predict</button>
+    <div id="spinner"></div>
+    <p id="result"></p>
+    <section id="log-wrapper">
+      <pre id="log"></pre>
+      <button id="copy-log-btn" title="Copy entire log">Copy log</button>
+    </section>
+  </div><!-- /root-rotate-wrapper -->
   <script src="https://cdn.jsdelivr.net/npm/onnxruntime-web@1.20.1/dist/ort.min.js"></script>
   <script type="module" src="app.js"></script>
 </body>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2,6 +2,7 @@
 h1,p{margin:0;}
 
 html,body{
+  width:100%;
   height:100dvh;
   max-height:100dvh;
   overflow:hidden;
@@ -21,6 +22,19 @@ html,body{
 body{
   display:flex;
   flex-direction:column;
+}
+
+@media (orientation: landscape){
+  #root-rotate-wrapper{
+    position:fixed;
+    top:0;
+    left:0;
+    width:100dvh;
+    height:100dvw;
+    transform-origin:0 0;
+    transform:rotate(90deg) translateY(-100dvh);
+    transition:transform .25s ease;
+  }
 }
 
 #preview-container {
@@ -95,29 +109,6 @@ button:active {
   white-space:pre-wrap;
 }
 
-/* ==== overlay «верните телефон» ============================== */
-#rotate-lock{
-  position:fixed;
-  inset:0;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  backdrop-filter:blur(4px);
-  background:rgba(0,0,0,.35);
-  z-index:9999;
-  pointer-events:none;
-}
-#rotate-lock .msg{
-  color:#fff;
-  font-size:18px;
-  font-weight:600;
-  text-align:center;
-  line-height:1.4;
-  padding:2rem 3rem;
-  border:2px solid rgba(255,255,255,.6);
-  border-radius:20px;
-  background:rgba(0,0,0,.25);
-}
 
 #copy-log-btn{
   position:absolute;


### PR DESCRIPTION
## Summary
- wrap page content in `#root-rotate-wrapper`
- rotate wrapper in landscape to keep portrait layout
- remove overlay orientation warning
- adjust JS to rotate wrapper and lock screen orientation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860082564a08320ba66a28d6bc7d042